### PR TITLE
WIP - initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,12 @@
 # Brodex
 
-**TODO: Add description**
+[Documentation](https://hexdocs.pm/brodex/)
+
+Brodex is a thin wrapper of [`:brod`](https://hex.pm/packages/brod).
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `brodex` to your list of dependencies in `mix.exs`:
-
-```elixir
-def deps do
-  [
-    {:brodex, "~> 0.1.0"}
-  ]
-end
-```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/brodex](https://hexdocs.pm/brodex).
+Brodex is available on [Hex](https://hex.pm/packages/brodex).
 
 ## License
 

--- a/lib/brodex.ex
+++ b/lib/brodex.ex
@@ -1,5 +1,220 @@
 defmodule Brodex do
   @moduledoc """
-  Documentation for Brodex.
+  Brodex is a thin wrapper of [`:brod`](https://hex.pm/packages/brod).
+
+  ## Configuration
+
+  See [brod README](https://github.com/klarna/brod) for details.
+
+  ```elixir
+  config :brod,
+    clients: [
+      my_client: [
+        endpoints: [{'127.0.0.1', 9092}],
+        reconnect_cool_down_seconds: 10
+      ]
+    ]
+  ```
+
+  If you use [mix release](https://hexdocs.pm/mix/Mix.Tasks.Release.html)
+
+  ```elixir
+  # config/releases.exs
+  config :brod,
+    clients: [
+      my_client: [
+        endpoints: Brodex.parse_endpoints(System.fetch_env!("KAFKA_ENDPOINTS)),
+        reconnect_cool_down_seconds: 10
+      ]
+    ]
+  ```
   """
+
+  @typedoc "[`:brod.endpoint`](https://hexdocs.pm/brod/brod.html#type-endpoint)"
+  @type endpoint :: {binary() | :inet.hostname(), non_neg_integer}
+
+  @typedoc "[`:brod.client_id`](https://hexdocs.pm/brod/brod.html#type-client_id)"
+  @type client_id :: atom
+
+  @typedoc "[`:brod.client`](https://hexdocs.pm/brod/brod.html#type-client)"
+  @type client :: client_id | pid
+
+  @typedoc "[`:brod.client_config`](https://hexdocs.pm/brod/brod.html#type-client_config)"
+  @type client_config :: :proplists.proplist()
+
+  @typedoc "[`:brod.connection`](https://hexdocs.pm/brod/brod.html#type-connection)"
+  @type connection :: pid
+
+  @typedoc "[`:brod.bootstrap`](https://hexdocs.pm/brod/brod.html#type-bootstrap)"
+  @type bootstrap :: [endpoint] | {[endpoint], client_config}
+
+  @typedoc "[`:brod.topic`](https://hexdocs.pm/brod/brod.html#type-topic)"
+  @type topic :: binary
+
+  @typedoc "[`:brod.partition`](https://hexdocs.pm/brod/brod.html#type-partition)"
+  @type partition :: int32
+
+  @typedoc "[`:brod.key`](https://hexdocs.pm/brod/brod.html#type-key)"
+  @type key :: :undefined | binary
+
+  @typedoc "[`:brod.offset`](https://hexdocs.pm/brod/brod.html#type-offset)"
+  @type offset :: int64
+
+  @typedoc "[`:brod.msg_ts`](https://hexdocs.pm/brod/brod.html#type-msg_ts)"
+  @type msg_ts :: int64
+
+  @typedoc "[`:brod.call_ref`](https://hexdocs.pm/brod/brod.html#type-call_ref)"
+  @type call_ref ::
+          {:brod_call_ref, caller :: :undefined | pid, callee :: :undefined | pid,
+           ref :: :undefined | reference}
+
+  @typedoc "[`:brod.consumer_config`](https://hexdocs.pm/brod/brod.html#type-consumer_config)"
+  @type consumer_config :: :proplists.proplist()
+
+  @typedoc "[`:brod.value`](https://hexdocs.pm/brod/brod.html#type-value)"
+  @type value ::
+          :undefined
+          | iodata
+          | {msg_ts, binary}
+          | [{key, value}]
+          | [{msg_ts, key, value}]
+          | msg_input
+          | batch_input
+
+  @typedoc "[`:kpro.headers`](https://hexdocs.pm/kafka_protocol/kpro.html#type-headers)"
+  @type headers :: [{binary, binary}]
+
+  @typedoc "[`:kpro.msg_input`](https://hexdocs.pm/kafka_protocol/kpro.html#type-msg_input)"
+  @type msg_input :: %{headers: headers, ts: msg_ts, key: key, value: value}
+
+  @typedoc "[`:kpro.batch_input`](https://hexdocs.pm/kafka_protocol/kpro.html#type-batch_input)"
+  @type batch_input :: [msg_input]
+
+  @typedoc "[`:brod.partitioner`](https://hexdocs.pm/brod/brod.html#type-partitioner)"
+  @type partitioner :: (topic, pos_integer, key, value -> {:ok, partition}) | :random | :hash
+
+  @typedoc "[`:brod.group_id`](https://hexdocs.pm/brod/brod.html#type-group_id)"
+  @type group_id :: binary
+
+  @typedoc "[`:brod.group_config`](https://hexdocs.pm/brod/brod.html#type-group_config)"
+  @type group_config :: :proplists.proplist()
+
+  @typedoc "[`:kpro.int32`](https://hexdocs.pm/kafka_protocol/kpro.html#type-int32)"
+  @type int32 :: -2_147_483_648..2_147_483_647
+
+  @typedoc "[`:kpro.int64`](https://hexdocs.pm/kafka_protocol/kpro.html#type-int64)"
+  @type int64 :: -9_223_372_036_854_775_808..9_223_372_036_854_775_807
+
+  @doc """
+  Wrapper of [`:brod.start_client/3`](https://hexdocs.pm/brod/brod.html#start_client-3).
+  """
+  @spec start_client([endpoint], client_id, :brod.client_config()) ::
+          :ok | {:error, term}
+  def start_client(endpoints, client_id, options \\ []),
+    do: :brod.start_client(endpoints, client_id, options)
+
+  @doc """
+  Wrapper of [`:brod.stop_client/1`](https://hexdocs.pm/brod/brod.html#stop_client-1).
+  """
+  @spec stop_client(client) :: :ok
+  def stop_client(client),
+    do: :brod.stop_client(client)
+
+  @doc """
+  Wrapper of [`:brod.produce/5`](https://hexdocs.pm/brod/brod.html#produce-5).
+  """
+  @spec produce_async(client, topic, input :: {key, value} | value, partition | partitioner) ::
+          {:ok, call_ref} | {:error, term}
+  def produce_async(client, topic, input, partition_spec \\ :hash)
+
+  def produce_async(client, topic, value, partition_spec) when is_list(value) or is_map(value),
+    do: :brod.produce(client, topic, partition_spec, "", value)
+
+  def produce_async(client, topic, {key, value}, partition_spec),
+    do: :brod.produce(client, topic, partition_spec, key, value)
+
+  @doc """
+  Wrapper of [`:brod.produce_sync/5`](https://hexdocs.pm/brod/brod.html#produce_sync-5).
+  """
+  @spec produce_sync(client, topic, input :: {key, value} | value, partition | partitioner) ::
+          :ok | {:error, term}
+  def produce_sync(client, topic, input, partition_spec \\ :hash)
+
+  def produce_sync(client, topic, value, partition_spec) when is_list(value) or is_map(value),
+    do: :brod.produce_sync(client, topic, partition_spec, "", value)
+
+  def produce_sync(client, topic, {key, value}, partition_spec),
+    do: :brod.produce_sync(client, topic, partition_spec, key, value)
+
+  @doc """
+  Wrapper of [`:brod.get_metadata/3`](https://hexdocs.pm/brod/brod.html#get_metadata-3)
+  """
+  @spec get_metadata([endpoint], :all | [topic], :brod.conn_config()) ::
+          {:ok, :kpro.struct()} | {:error, term}
+  def get_metadata(endpoints, topic, connect_config \\ []),
+    do: :brod.get_metadata(endpoints, topic, connect_config)
+
+  @doc """
+  Wrapper of [`:brod.get_partitions_count/2`](https://hexdocs.pm/brod/brod.html#get_partitions_count-2)
+  """
+  @spec get_partitions_count(client, topic) :: {:ok, pos_integer} | {:error, term}
+  def get_partitions_count(client, topic), do: :brod.get_partitions_count(client, topic)
+
+  @doc """
+  Wrapper of [`:brod.list_all_groups/2`](https://hexdocs.pm/brod/brod.html#list_all_groups-2)
+  """
+  @spec list_all_consumer_groups([endpoint], :brod.conn_config()) :: [
+          {endpoint, [:brod.cg()] | {:error, term}}
+        ]
+  def list_all_consumer_groups(endpoints, connect_config \\ []),
+    do: :brod.list_all_groups(endpoints, connect_config)
+
+  @doc """
+  Wrapper of [`:brod.list_groups/2`](https://hexdocs.pm/brod/brod.html#list_groups-2)
+  """
+  @spec list_consumer_groups(endpoint, :brod.conn_config()) ::
+          {:ok, [:brod.cg()]} | {:error, term}
+
+  def list_consumer_groups(endpoint, connect_config \\ []),
+    do: :brod.list_groups(endpoint, connect_config)
+
+  @type fetch_opt ::
+          {:max_wait_time, non_neg_integer}
+          | {:min_bytes, non_neg_integer}
+          | {:max_bytes, non_neg_integer}
+  @doc """
+  Wrapper of [`:brod.fetch/5`](https://hexdocs.pm/brod/brod.html#fetch-5)
+  """
+  @spec fetch(
+          connection | client_id | bootstrap,
+          topic,
+          partition,
+          offset,
+          [fetch_opt]
+        ) ::
+          {:ok, {offset, [Brodex.Message.record()]}} | {:error, term}
+  def fetch(conn_spec, topic, partition, offset, options \\ []),
+    do: :brod.fetch(conn_spec, topic, partition, offset, Enum.into(options, %{}))
+
+  @doc """
+  Parse endpoints.
+
+  ## Examples
+
+      iex> Brodex.parse_endpoints("kafka1:9000,kafka:9001")
+      [{'kafka1', 9000}, {'kafka', 9001}]
+
+  """
+  @spec parse_endpoints(String.t()) :: [endpoint]
+  def parse_endpoints(endpoints)
+
+  def parse_endpoints(endpoints) when is_binary(endpoints) do
+    endpoints
+    |> String.split(",")
+    |> Enum.map(fn host_port ->
+      [host, port] = String.split(host_port, ":")
+      {port, ""} = Integer.parse(port)
+      {to_charlist(host), port}
+    end)
+  end
 end

--- a/lib/brodex/group_subscriber.ex
+++ b/lib/brodex/group_subscriber.ex
@@ -1,0 +1,64 @@
+defmodule Brodex.GroupSubscriber do
+  @moduledoc """
+  Wrapper of [`:brod_group_subscriber`](https://hexdocs.pm/brod/brod_group_subscriber.html).
+  """
+
+  @callback init(group_id :: Brodex.group_id(), term) ::
+              {:ok, callback_state}
+
+  @callback handle_message(
+              topic :: Brodex.topic(),
+              partition :: Brodex.partition(),
+              message_or_message_set :: Brodex.Message.record() | Brodex.MessageSet.record(),
+              callback_state :: callback_state
+            ) ::
+              {:ok, callback_state}
+              | {:ok, :ack, callback_state}
+              | {:ok, :ack_no_commit, callback_state}
+
+  @typedoc """
+  A spec for callback.
+
+  `module` must implement `Brodex.GroupSubscriber` behaviour.
+  """
+  @type callback_spec :: module | {module, any}
+
+  @typedoc "[`:brod_group_subscriber.cb_state`](https://hexdocs.pm/brod/brod_group_subscriber.html#type-cb_state)"
+  @type callback_state :: term
+
+  @type start_link_option ::
+          {:group_config, Brodex.group_config()}
+          | {:consumer_config, Brodex.consumer_config()}
+          | {:message_type, :message | :message_set}
+
+  @doc """
+  Wrapper of [`:brod_group_subscriber.start_link/8`](https://hexdocs.pm/brod/brod_group_subscriber.html#start_link-8).
+  """
+  @spec start_link(Brodex.client(), Brodex.group_id(), [Brodex.topic()], callback_spec, [
+          start_link_option
+        ]) ::
+          {:ok, pid} | {:error, term}
+  def start_link(client, group_id, topics, callback_spec, options)
+
+  def start_link(client, group_id, topics, {mod, args}, options) do
+    :brod_group_subscriber.start_link(
+      client,
+      group_id,
+      topics,
+      Keyword.get(options, :group_config, []),
+      Keyword.get(options, :consumer_config, []),
+      Keyword.get(options, :message_type, :message),
+      mod,
+      args
+    )
+  end
+
+  def start_link(client, group_id, topics, mod, options) when is_atom(mod),
+    do: start_link(client, group_id, topics, {mod, []}, options)
+
+  @doc """
+  Wrapper of [`:brod_group_subscriber.stop/1`](https://hexdocs.pm/brod/brod_group_subscriber.html#stop-1).
+  """
+  @spec stop(pid) :: :ok
+  def stop(pid), do: :brod_group_subscriber.stop(pid)
+end

--- a/lib/brodex/guards.ex
+++ b/lib/brodex/guards.ex
@@ -1,0 +1,43 @@
+defmodule Brodex.Guards do
+  @doc """
+  Return `true`if `term` is `t:Brodex.Message.record/0`.
+
+  ## Examples
+
+      iex>  Brodex.Guards.is_message_record({:kafka_message, 164, "", "hello", :create, 1_563_946_803_056, []})
+      true
+
+
+      iex>  Brodex.Guards.is_message_record(
+      ...>    {:kafka_message_set, "my_topic", 0, 33,
+      ...>    [
+      ...>      {:kafka_message, 31, "", "a", :create, 1_564_023_091_657, []},
+      ...>      {:kafka_message, 32, "", "b", :create, 1_564_023_091_894, []}
+      ...>    ]}
+      ...>  )
+      false
+
+  """
+  defguard is_message_record(term)
+           when is_tuple(term) and tuple_size(term) == 7 and elem(term, 0) == :kafka_message
+
+  @doc """
+  Return `true`if `term` is `t:Brodex.MessageSet.record/0`.
+
+  ## Examples
+
+      iex>  Brodex.Guards.is_message_set_record(
+      ...>    {:kafka_message_set, "my_topic", 0, 33,
+      ...>    [
+      ...>      {:kafka_message, 31, "", "a", :create, 1_564_023_091_657, []},
+      ...>      {:kafka_message, 32, "", "b", :create, 1_564_023_091_894, []}
+      ...>    ]}
+      ...>  )
+      true
+
+      iex>  Brodex.Guards.is_message_set_record({:kafka_message, 164, "", "hello", :create, 1_563_946_803_056, []})
+      false
+  """
+  defguard is_message_set_record(term)
+           when is_tuple(term) and tuple_size(term) == 5 and elem(term, 0) == :kafka_message_set
+end

--- a/lib/brodex/message.ex
+++ b/lib/brodex/message.ex
@@ -1,0 +1,61 @@
+defmodule Brodex.Message do
+  @moduledoc """
+  Represents a Kafka message.
+
+  Wrapper of [`:brod.message`](https://hexdocs.pm/brod/brod.html#type-message).
+  """
+
+  require Record
+
+  @type t :: %__MODULE__{
+          offset: Brodex.offest(),
+          key: Brodex.key(),
+          value: Brodex.value(),
+          ts_type: timestamp_type,
+          ts: :undefined | Brodex.int64(),
+          headers: Brodex.headers()
+        }
+
+  @typedoc "[`:brod.message`](https://hexdocs.pm/brod/brod.html#type-message)"
+  @type record ::
+          {:kafka_message, offset :: Brodex.offest(), key :: Brodex.key(),
+           value :: Brodex.value(), ts_type :: timestamp_type, ts :: :undefined | Brodex.int64(),
+           headers :: Brodex.headers()}
+
+  @typedoc "[`:kpro.timestamp_type`](https://hexdocs.pm/kafka_protocol/kpro.html#type-timestamp_type)"
+  @type timestamp_type :: :undefined | :create | :append
+
+  defstruct [:offset, :key, :value, :ts_type, :ts, :headers]
+
+  @doc """
+  Converts a `t:record/0` into a `Brodex.Message`.
+
+  ## Examples
+
+      iex> Brodex.Message.from_record({:kafka_message, 164, "", "hello", :create, 1_563_946_803_056, []})
+      %Brodex.Message{
+        headers: [],
+        key: "",
+        offset: 164,
+        ts: 1_563_946_803_056,
+        ts_type: :create,
+        value: "hello"
+      }
+
+      iex> Brodex.Message.from_record({:kafka_message, 164, "", "hello", :undefined, :undefined, []})
+      %Brodex.Message{
+        headers: [],
+        key: "",
+        offset: 164,
+        ts: :undefined,
+        ts_type: :undefined,
+        value: "hello"
+      }
+
+  """
+  @spec from_record(record) :: t
+  def from_record(kafka_message_record)
+
+  def from_record({:kafka_message, offset, k, v, ts_type, ts, headers}),
+    do: %__MODULE__{offset: offset, key: k, value: v, ts_type: ts_type, ts: ts, headers: headers}
+end

--- a/lib/brodex/message_set.ex
+++ b/lib/brodex/message_set.ex
@@ -1,0 +1,74 @@
+defmodule Brodex.MessageSet do
+  @moduledoc """
+  Represents a Kafka message set.
+
+  Wrapper of [`:brod.message_set`](https://hexdocs.pm/brod/brod.html#type-message_set).
+  """
+
+  @type t :: %__MODULE__{
+          topic: Brodex.topic(),
+          partition: Brodex.partition(),
+          high_wm_offset: integer,
+          messages: [Brodex.Message.t()] | {:incomplete_batch, Brodex.int32()}
+        }
+
+  @typedoc "[`:brod.message_set`](https://hexdocs.pm/brod/brod.html#type-message_set)"
+  @type record ::
+          {:kafka_message_set, topic :: Brodex.topic(), partition :: Brodex.partition(),
+           high_wm_offset :: integer,
+           messages :: [Brodex.record()] | {:incomplete_batch, Brodex.int32()}}
+
+  defstruct [:topic, :partition, :high_wm_offset, :messages]
+
+  @doc """
+  Converts a `t:record/0` into a `Brodex.MessageSet`.
+
+  ## Examples
+
+      iex>  Brodex.MessageSet.from_record(
+      ...>    {:kafka_message_set, "my_topic", 0, 33,
+      ...>    [
+      ...>      {:kafka_message, 31, "", "a", :create, 1_564_023_091_657, []},
+      ...>      {:kafka_message, 32, "", "b", :create, 1_564_023_091_894, []}
+      ...>    ]}
+      ...>  )
+      %Brodex.MessageSet{
+        high_wm_offset: 33,
+        messages: [
+          %Brodex.Message{
+            headers: [],
+            key: "",
+            offset: 31,
+            ts: 1_564_023_091_657,
+            ts_type: :create,
+            value: "a"
+          },
+          %Brodex.Message{
+            headers: [],
+            key: "",
+            offset: 32,
+            ts: 1_564_023_091_894,
+            ts_type: :create,
+            value: "b"
+          }
+        ],
+        partition: 0,
+        topic: "my_topic"
+      }
+
+  """
+  @spec from_record(record) :: t
+  def from_record(kafka_message_set_record)
+
+  def from_record({:kafka_message_set, t, p, o, messages}),
+    do: %__MODULE__{
+      topic: t,
+      partition: p,
+      high_wm_offset: o,
+      messages: Enum.map(messages, &cast_message/1)
+    }
+
+  defp cast_message(message) when is_tuple(message), do: Brodex.Message.from_record(message)
+
+  defp cast_message(message), do: message
+end

--- a/lib/brodex/topic_subscriber.ex
+++ b/lib/brodex/topic_subscriber.ex
@@ -1,0 +1,73 @@
+defmodule Brodex.TopicSubscriber do
+  @moduledoc """
+  Wrapper of [`:brod_topic_subscriber`](https://hexdocs.pm/brod/brod_topic_subscriber.html).
+  """
+
+  @callback init(topic :: Brodex.topic(), term) ::
+              {:ok, committed_offsets, :brod_topic_subscriber.cb_state()}
+
+  @callback handle_message(
+              partition :: Brodex.partition(),
+              message_or_message_set :: Brodex.Message.record() | Brodex.MessageSet.record(),
+              callback_state :: callback_state
+            ) :: {:ok, callback_state} | {:ok, :ack, callback_state}
+
+  @typedoc """
+  A spec for callback.
+
+  `module` must implement `Brodex.TopicSubscriber` behaviour.
+  """
+  @type callback_spec :: module | {module, any}
+
+  @typedoc "[`:brod_topic_subscriber.cb_state`](https://hexdocs.pm/brod/brod_topic_subscriber.html#type-cb_state)"
+  @type callback_state :: term
+
+  @typedoc "[`:brod_topic_subscriber.committed_offsets`](https://hexdocs.pm/brod/brod_topic_subscriber.html#type-committed_offsets)"
+  @type committed_offsets :: [{Brodex.parition(), Brodex.offset()}]
+
+  @type start_link_option ::
+          {:client, Brodex.client()}
+          | {:partition, :all | [Brodex.partition()]}
+          | {:consumer_config, Brodex.consumer_config()}
+          | {:message_type, :message | :message_set}
+
+  @doc """
+  Wrapper of [`:brod_topic_subscriber.start_link/7`](https://hexdocs.pm/brod/brod_topic_subscriber.html#start_link-7).
+  """
+  @spec start_link(Brodex.client(), Brodex.topic(), callback_spec, [start_link_option]) ::
+          {:ok, pid} | {:error, term}
+  def start_link(client, topic, callback_spec, options \\ [])
+
+  def start_link(client, topic, {mod, args}, options) when is_atom(mod) do
+    brod_args =
+      [
+        client,
+        topic,
+        Keyword.get(options, :partition, :all),
+        Keyword.get(options, :consumer_config, [])
+      ]
+      |> add_arg(options, :committed_offset)
+      |> add_arg(options, :message_type)
+
+    brod_args = brod_args ++ [mod, args]
+
+    apply(:brod_topic_subscriber, :start_link, brod_args)
+  end
+
+  def start_link(client, topic, mod, options) when is_atom(mod),
+    do: start_link(client, topic, {mod, []}, options)
+
+  defp add_arg(args, options, key) do
+    if Keyword.has_key?(options, key) do
+      args ++ [Keyword.get(options, key)]
+    else
+      args
+    end
+  end
+
+  @doc """
+  Wrapper of [`:brod_topic_subscriber.stop/1`](https://hexdocs.pm/brod/brod_topic_subscriber.html#stop-1).
+  """
+  @spec stop(pid) :: :ok
+  def stop(pid), do: :brod_topic_subscriber.stop(pid)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,10 @@ defmodule Brodex.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       # hex
+      description: "A thin wrapper of brod.",
       package: [
-        licenses: ["Apache-2.0"]
+        licenses: ["Apache-2.0"],
+        links: %{"GitHub" => "https://github.com/chulkilee/brodex"}
       ],
       # docs
       source_url: "https://github.com/chulkilee/brodex"

--- a/test/brodex/guards_test.exs
+++ b/test/brodex/guards_test.exs
@@ -1,0 +1,4 @@
+defmodule Brodex.GuardsTest do
+  use ExUnit.Case, async: true
+  doctest Brodex.Guards
+end

--- a/test/brodex/message_set_test.exs
+++ b/test/brodex/message_set_test.exs
@@ -1,0 +1,4 @@
+defmodule Brodex.MessageSetTest do
+  use ExUnit.Case, async: true
+  doctest Brodex.MessageSet
+end

--- a/test/brodex/message_test.exs
+++ b/test/brodex/message_test.exs
@@ -1,0 +1,4 @@
+defmodule Brodex.MessageTest do
+  use ExUnit.Case, async: true
+  doctest Brodex.Message
+end


### PR DESCRIPTION
*Warning: I may rewrite history of this branch, so do not rely on commit ref*

Add very thin wrapper for [brod](https://hex.pm/packages/brod)! See [brod documentation](https://hexdocs.pm/brod/)

## Goal

- Easier navigation with ExDoc doc
- Elixir module structure: e.g. `Brodex.TopicSubscriber` for `:brod_topic_Subscriber`
- Avoid equivalent funcs, such as `:brod.start_link_topic_subscriber/7` <=> `:brod_topic_subscriber:start_link/7` => put it only under `Brodex.TopicSubscriber`

## Non-goal

- Change structure or transform value of `:brod` structure (e.g. keep `:undefined`, not converting it to `nil`)
- Add more abstraction, such as own GenServer

## Example

```elixir
defmodule Helper do
  import Brodex.Guards

  def inspect_message(message_record, context) when is_message_record(message_record) do
    IO.inspect(
      context ++
        [
          message_record: message_record,
          message_struct: Brodex.Message.from_record(message_record)
        ]
    )
  end

  def inspect_message(message_set_record, context)
      when is_message_set_record(message_set_record) do
    IO.inspect(
      context ++
        [
          message_set_record: message_set_record,
          message_set_struct: Brodex.MessageSet.from_record(message_set_record)
        ]
    )
  end
end

defmodule MyTopicSubscriber do
  @behaviour Brodex.TopicSubscriber

  @impl Brodex.TopicSubscriber
  def init(_topic, args), do: {:ok, _committed_offset = [], args}

  @impl Brodex.TopicSubscriber
  def handle_message(partition, message_or_message_set, state) do
    Helper.inspect_message(message_or_message_set, partition: partition, state: state)

    {:ok, :ack, state}
  end
end

defmodule MyGroupSubscriber do
  @behaviour Brodex.GroupSubscriber

  @impl Brodex.GroupSubscriber
  def init(_group_id, args), do: {:ok, args}

  @impl Brodex.GroupSubscriber
  def handle_message(topic, partition, message_or_message_set, state) do
    Helper.inspect_message(message_or_message_set,
      topic: topic,
      partition: partition,
      state: state
    )

    {:ok, :ack, state}
  end
end

[endpoint] = endpoints = [{'127.0.0.1', 9092}]
topic = "my_topic"
group_id = "my_group"

{:ok, _} = Brodex.get_metadata(endpoints, :all)
{:ok, _} = Brodex.get_metadata(endpoints, [topic])

:ok = Brodex.start_client(endpoints, :topic_message_set_client)
:ok = Brodex.start_client(endpoints, :topic_message_client)
:ok = Brodex.start_client(endpoints, :group_message_set_client)
:ok = Brodex.start_client(endpoints, :group_message_client)

{:ok, _} = Brodex.get_partitions_count(:topic_message_set_client, topic)

Brodex.list_all_consumer_groups(endpoints)
{:ok, _} = Brodex.list_consumer_groups(endpoint)

:ok =
  Brodex.start_client(endpoints, :produce_client,
    reconnect_cool_down_seconds: 10,
    auto_start_producers: true
  )

{:ok, topic_message_set_pid} =
  Brodex.TopicSubscriber.start_link(
    :topic_message_set_client,
    topic,
    {MyTopicSubscriber, [name: "topic_message_set"]},
    message_type: :message_set
  )

{:ok, topic_message_pid} =
  Brodex.TopicSubscriber.start_link(
    :topic_message_client,
    topic,
    {MyTopicSubscriber, [name: "topic_message"]},
    message_type: :message
  )

{:ok, group_message_set_pid} =
  Brodex.GroupSubscriber.start_link(
    :group_message_set_client,
    group_id,
    [topic],
    {MyGroupSubscriber, [name: "group_message_set"]},
    message_type: :message_set
  )

{:ok, group_message_pid} =
  Brodex.GroupSubscriber.start_link(
    :group_message_client,
    group_id,
    [topic],
    {MyGroupSubscriber, [name: "group_message"]},
    message_type: :message
  )

# single message
{:ok, _brod_call_ref_record} = Brodex.produce_async(:produce_client, topic, {"key1", "async1"})

:ok = Brodex.produce_sync(:produce_client, "my_topic", {"key1", "sync1"})

# multiple message
{:ok, _brod_call_ref_record} =
  Brodex.produce_async(
    :produce_client,
    "my_topic",
    [
      {"key1", "async1"},
      {"key2", "async2"},
      {"key3", "async3"}
    ]
  )

:ok =
  Brodex.produce_sync(
    :produce_client,
    "my_topic",
    [
      {"key1", "sync1"},
      {"key2", "sync2"},
      {"key3", "sync3"}
    ]
  )

:ok = Brodex.TopicSubscriber.stop(topic_message_set_pid)
:ok = Brodex.TopicSubscriber.stop(topic_message_pid)
:ok = Brodex.GroupSubscriber.stop(group_message_set_pid)
:ok = Brodex.GroupSubscriber.stop(group_message_pid)

# :ok = Brodex.stop_client(:message_set_client)
# :ok = Brodex.stop_client(:message_client)
```